### PR TITLE
[ Open Api ] Accounting for Optin JsonObjects

### DIFF
--- a/Azure.Functions.Worker.Extensions.MediatR/OpenApi/CustomObjectTypeVisitor.cs
+++ b/Azure.Functions.Worker.Extensions.MediatR/OpenApi/CustomObjectTypeVisitor.cs
@@ -55,9 +55,14 @@ public class CustomObjectTypeVisitor(
         OpenApiSchemaAcceptor instance = acceptor as OpenApiSchemaAcceptor;
         if (instance.IsNullOrDefault<OpenApiSchemaAcceptor>())
             return;
+        
+        var isOptIn = type.Value.GetCustomAttribute<JsonObjectAttribute>(false)
+            ?.MemberSerialization == MemberSerialization.OptIn;;
+        
         Dictionary<string, PropertyInfo> dictionary = type.Value
             .GetProperties(BindingFlags.Instance | BindingFlags.Public)
-            .Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>() &&
+            .Where(p => !p.ExistsCustomAttribute<JsonIgnoreAttribute>() && 
+                        (!isOptIn || p.ExistsCustomAttribute<JsonPropertyAttribute>()) &&
                         !p.ExistsCustomAttribute<FromQueryAttribute>() &&
                         !p.ExistsCustomAttribute<FromRouteAttribute>())
             .ToDictionary(p => p.GetJsonPropertyName(namingStrategy), p => p);


### PR DESCRIPTION
- **What does this PR do?**  
  Accounts for opt-in JSON objects in the Open API implementation, ensuring proper handling and improved flexibility.

- **Why is this change needed?**  
  This change ensures that optional JSON objects are properly considered and integrated within the Open API.

- **Implementation Details:**  
  Adjusts handling for optional JSON objects to align with the expected API behavior.